### PR TITLE
Fixes to be able to run homely

### DIFF
--- a/homely/_ui.py
+++ b/homely/_ui.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import sys
 import time
 from contextlib import contextmanager
@@ -341,7 +342,7 @@ def addfromremote(repo, dest_path):
             return RepoInfo(destrepo, destid), True
 
         # move our temporary clone into the final destination
-        os.rename(tmp, dest_path)
+        shutil.move(tmp, dest_path)
 
     destrepo = localrepo.frompath(dest_path)
     assert destrepo is not None

--- a/homely/_utils.py
+++ b/homely/_utils.py
@@ -528,7 +528,7 @@ def filereplacer(filepath):
         raise
     if os.path.exists(filepath):
         os.unlink(filepath)
-    os.rename(tmpname, filepath)
+    shutil.move(tmpname, filepath)
 
 
 def isnecessarypath(parent, child):

--- a/homely/_vcs/git.py
+++ b/homely/_vcs/git.py
@@ -24,14 +24,20 @@ class Repo(homely._vcs.Repo):
         if (repo_path.startswith('ssh://') or
                 repo_path.startswith('https://') or
                 repo_path.startswith('git@')):
-            m = re.match(r'^(https://|git@)github\.com[/:]([^/]+)/([^/]+)',
+
+            m = re.match(r'^(https://|git@)([^/]+)[/:]([^/]+)/([^/]+)',
                          repo_path)
+                         
             if not m:
-                return
-            _, user, name = m.groups()
+                return class_(repo_path, 
+                              isremote=True, 
+                              iscanonical=False, 
+                              suggestedlocal=None)
+
+            _, user, domain, name = m.groups()
             if name.endswith('.git'):
                 name = name[0:-4]
-            canonical = 'https://github.com/%s/%s.git' % (user, name)
+            canonical = 'https://%s/%s/%s.git' % (domain, user, name)
             return class_(repo_path,
                           isremote=True,
                           iscanonical=repo_path == canonical,

--- a/publish.py
+++ b/publish.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import glob
 import os
+import shutil
 import sys
 from datetime import date
 from subprocess import check_call, check_output
@@ -93,7 +94,7 @@ def updatechangelog(new_tag, latest_tag):
     check_call(['vim', changelog_new] + splitcmds)
 
     # move file sideways and commit it
-    os.rename(changelog_new, changelog_old)
+    shutil.move(changelog_new, changelog_old)
     check_call(['git', 'commit', changelog_old, '-m', 'Update changelog'])
 
 


### PR DESCRIPTION
I wanted to try out `homely` but I was unable to set-up it on my Linux machine.

I encountered two issues:

* Passing a git repo address which was not located on github would fail. This is likely causing Issue #47. I'm unsure what is the intention with the parsing in the `Repo.frompath).
* The `os.rename` would not work when `/tmp` is mounted in a a different filesystem. Replacing with `shutil.move` does the trick (on python3).




