### PR TITLE
New force_git_config fixture to replace old 'GIT + [...]' mechanism

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,9 @@ import os.path
 import shutil
 import sys
 import tempfile
-from typing import Optional
+from pathlib import Path
+from textwrap import dedent
+from typing import Iterator, Optional
 
 import pytest
 
@@ -68,3 +70,33 @@ def testrepo2(HOME, tmpdir):
     # homely-add the repo
     from homely._test.system import TempRepo
     yield _get_test_repo(TempRepo(tmpdir, 'cool-testrepo-2'))
+
+
+@pytest.fixture(autouse=True, scope='session')
+def force_git_config() -> Iterator[None]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # force git commands to use a gitconfig that will:
+        # A) provide a user.name/user.email for committing
+        # B) allow the "file" protocol so that submodules can be cloned from
+        #    filesystem paths instead of URLs
+        # C) prevent anything in the host's user git config (like
+        #    core.hooksPath) from slowing down or interfereing with tests.
+        gitconfigpath = Path(tmpdir) / 'gitconfig'
+        gitconfigpath.write_text(
+            dedent(
+                '''
+                [protocol.file]
+                    allow = always
+                [user]
+                    name = "John Smith"
+                    email = "john@example.com"
+                '''
+            )
+        )
+        m = pytest.MonkeyPatch()
+        try:
+            # prevent reading any local git config during the tests
+            m.setenv('GIT_CONFIG_GLOBAL', str(gitconfigpath))
+            yield
+        finally:
+            m.undo()

--- a/test/unit/homely/_vcs/test_git.py
+++ b/test/unit/homely/_vcs/test_git.py
@@ -5,13 +5,8 @@ from subprocess import check_call
 
 from homely._test import contents
 
-GIT = [
-    'git',
-    '-c',
-    'user.name=John Smith',
-    '-c',
-    'user.email=john@example.com',
-]
+# TODO: get rid of this thing
+GIT: list[str | os.PathLike] = ['git']
 
 
 def makegitrepo(tmpdir, name):


### PR DESCRIPTION
This fixture more reliably sets a known git config across the whole project, not just commands executed directly by the tests.